### PR TITLE
Bitbucket edits, breaking change in list repos method

### DIFF
--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -16,7 +16,7 @@ type organizationService struct {
 }
 
 func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organization, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/teams/%s", name)
+	path := fmt.Sprintf("2.0/workspaces/%s", name)
 	out := new(organization)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	return convertOrganization(out), res, err
@@ -27,7 +27,7 @@ func (s *organizationService) FindMembership(ctx context.Context, name, username
 }
 
 func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/teams?%s", encodeListRoleOptions(opts))
+	path := fmt.Sprintf("2.0/workspaces?%s", encodeListRoleOptions(opts))
 	out := new(organizationList)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)
@@ -48,7 +48,7 @@ type organizationList struct {
 }
 
 type organization struct {
-	Login string `json:"username"`
+	Login string `json:"slug"`
 }
 
 func convertOrganization(from *organization) *scm.Organization {

--- a/scm/driver/bitbucket/org_test.go
+++ b/scm/driver/bitbucket/org_test.go
@@ -20,7 +20,7 @@ func TestOrganizationFind(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/teams/atlassian").
+		Get("/2.0/workspaces/atlassian").
 		Reply(200).
 		Type("application/json").
 		File("testdata/team.json")
@@ -45,7 +45,7 @@ func TestOrganizationList(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/teams").
+		Get("/2.0/workspaces").
 		MatchParam("pagelen", "30").
 		MatchParam("page", "1").
 		Reply(200).

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -280,7 +280,7 @@ func anonymizeLink(link string) (href string) {
 }
 
 func convertPermissionList(from *permissionList) map[string]*scm.Perm {
-	permissionMap := new(map[string]*scm.Perm)
+	permissionMap := make(map[string]*scm.Perm)
 
 	for _, value := range from.Values {
 		to := new(scm.Perm)
@@ -295,9 +295,9 @@ func convertPermissionList(from *permissionList) map[string]*scm.Perm {
 		default:
 			to.Pull = true
 		}
-		(*permissionMap)[value.Repository.UUID] = to
+		permissionMap[value.Repository.UUID] = to
 	}
-	return (*permissionMap)
+	return permissionMap
 }
 
 func convertPerms(from *perms) *scm.Perm {

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -225,17 +225,10 @@ func (s *repositoryService) DeleteHook(ctx context.Context, repo string, id stri
 // helper function to convert from the gogs repository list to
 // the common repository structure.
 func convertRepositoryList(from *repositories, permissionMap map[string]*scm.Perm) []*scm.Repository {
-	fmt.Println(permissionMap)
 	to := []*scm.Repository{}
 	for _, v := range from.Values {
 		convertedRepo := convertRepository(v)
 		convertedRepo.Perm = permissionMap[v.UUID]
-
-		if convertedRepo.Perm == nil {
-			convertedRepo.Perm = new(scm.Perm)
-		}
-
-		fmt.Println(convertedRepo)
 		to = append(to, convertedRepo)
 	}
 	return to

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -86,14 +86,13 @@ type repositoryService struct {
 
 // Find returns the repository by name.
 func (s *repositoryService) Find(ctx context.Context, repo string) (*scm.Repository, *scm.Response, error) {
-	repoPerm, res, err := s.FindPerms(ctx, repo)
+	path := fmt.Sprintf("2.0/repositories/%s", repo)
+	out := new(repository)
+	res, err := s.client.do(ctx, "GET", path, nil, out)
 	if err != nil {
 		return nil, res, err
 	}
-
-	path := fmt.Sprintf("2.0/repositories/%s", repo)
-	out := new(repository)
-	res, err = s.client.do(ctx, "GET", path, nil, out)
+	repoPerm, _, err := s.FindPerms(ctx, repo)
 	return convertRepository(out, repoPerm), res, err
 }
 

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -225,10 +225,13 @@ func (s *repositoryService) DeleteHook(ctx context.Context, repo string, id stri
 // helper function to convert from the gogs repository list to
 // the common repository structure.
 func convertRepositoryList(from *repositories, permissionMap map[string]*scm.Perm) []*scm.Repository {
+	fmt.Println(permissionMap)
 	to := []*scm.Repository{}
 	for _, v := range from.Values {
 		convertedRepo := convertRepository(v)
 		convertedRepo.Perm = permissionMap[v.UUID]
+
+		fmt.Println(convertedRepo)
 		to = append(to, convertedRepo)
 	}
 	return to

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -231,6 +231,10 @@ func convertRepositoryList(from *repositories, permissionMap map[string]*scm.Per
 		convertedRepo := convertRepository(v)
 		convertedRepo.Perm = permissionMap[v.UUID]
 
+		if convertedRepo.Perm == nil {
+			convertedRepo.Perm = new(scm.Perm)
+		}
+
 		fmt.Println(convertedRepo)
 		to = append(to, convertedRepo)
 	}

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -112,7 +112,7 @@ func TestRepositoryList(t *testing.T) {
 	client, _ := New("https://api.bitbucket.org")
 
 	for {
-		repos, res, err := client.Repositories.List(context.Background(), opts)
+		repos, res, err := client.Repositories.List(context.Background(), "", opts)
 		if err != nil {
 			t.Error(err)
 		}

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -25,6 +25,13 @@ func TestRepositoryFind(t *testing.T) {
 		Type("application/json").
 		File("testdata/repo.json")
 
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/permissions/repositories").
+		MatchParam("q", `repository.full_name="atlassian/stash-example-plugin"`).
+		Reply(200).
+		Type("application/json").
+		File("testdata/perms.json")
+
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Repositories.Find(context.Background(), "atlassian/stash-example-plugin")
 	if err != nil {
@@ -50,6 +57,13 @@ func TestRepositoryFind_NotFound(t *testing.T) {
 		Type("application/json").
 		File("testdata/error.json")
 
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/permissions/repositories").
+		MatchParam("q", `repository.full_name="dev/null"`).
+		Reply(404).
+		Type("application/json").
+		File("testdata/perms.json")
+
 	client, _ := New("https://api.bitbucket.org")
 	_, _, err := client.Repositories.Find(context.Background(), "dev/null")
 	if err == nil {
@@ -66,7 +80,7 @@ func TestRepositoryPerms(t *testing.T) {
 
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/permissions/repositories").
-		// MatchParam("repository.full_name", `"atlassian/stash-example-plugin"`).
+		MatchParam("q", `repository.full_name="atlassian/stash-example-plugin"`).
 		Reply(200).
 		Type("application/json").
 		File("testdata/perms.json")
@@ -112,7 +126,13 @@ func TestRepositoryList(t *testing.T) {
 	client, _ := New("https://api.bitbucket.org")
 
 	for {
-		repos, res, err := client.Repositories.List(context.Background(), "", opts)
+		gock.New("https://api.bitbucket.org").
+			Get("/2.0/user/permissions/repositories").
+			Reply(200).
+			Type("application/json").
+			File("testdata/perms.json")
+
+		repos, res, err := client.Repositories.List(context.Background(), "atlassian", opts)
 		if err != nil {
 			t.Error(err)
 		}

--- a/scm/driver/bitbucket/testdata/email.json
+++ b/scm/driver/bitbucket/testdata/email.json
@@ -1,0 +1,18 @@
+{
+    "pagelen": 10,
+    "values": [
+        {
+            "is_primary": true,
+            "is_confirmed": true,
+            "type": "email",
+            "email": "utkarsh.gupta.cer15@itbhu.ac.in",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/user/emails/utkarsh.gupta.cer15@itbhu.ac.in"
+                }
+            }
+        }
+    ],
+    "page": 1,
+    "size": 1
+}

--- a/scm/driver/bitbucket/testdata/repo.json
+++ b/scm/driver/bitbucket/testdata/repo.json
@@ -1,83 +1,56 @@
 {
   "scm": "git",
-  "website": "",
   "has_wiki": false,
-  "uuid": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
   "links": {
     "watchers": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/watchers"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/watchers"
     },
     "branches": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/refs\/branches"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/refs/branches"
     },
     "tags": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/refs\/tags"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/refs/tags"
     },
     "commits": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commits"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/commits"
     },
     "clone": [
       {
-        "href": "https:\/\/brydzewski@bitbucket.org\/atlassian\/stash-example-plugin.git",
+        "href": "https://bitbucket.org/atlassian/stash-example-plugin.git",
         "name": "https"
       },
       {
-        "href": "git@bitbucket.org:atlassian\/stash-example-plugin.git",
+        "href": "git@bitbucket.org:atlassian/stash-example-plugin.git",
         "name": "ssh"
       }
     ],
     "self": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin"
     },
     "source": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/src"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/src"
     },
     "html": {
-      "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin"
+      "href": "https://bitbucket.org/atlassian/stash-example-plugin"
     },
     "avatar": {
-      "href": "https:\/\/bytebucket.org\/ravatar\/%7B7dd600e6-0d9c-4801-b967-cb4cc17359ff%7D?ts=default"
+      "href": "https://bytebucket.org/ravatar/%7B7dd600e6-0d9c-4801-b967-cb4cc17359ff%7D?ts=default"
     },
     "hooks": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/hooks"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/hooks"
     },
     "forks": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/forks"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/forks"
     },
     "downloads": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/downloads"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/downloads"
     },
     "pullrequests": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/pullrequests"
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian/stash-example-plugin/pullrequests"
     }
   },
-  "fork_policy": "allow_forks",
-  "name": "stash-example-plugin",
-  "project": {
-    "key": "PROJ",
-    "type": "project",
-    "uuid": "{8b56daff-dbc7-4cae-a7a3-1228c526906b}",
-    "links": {
-      "self": {
-        "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian\/projects\/PROJ"
-      },
-      "html": {
-        "href": "https:\/\/bitbucket.org\/account\/user\/atlassian\/projects\/PROJ"
-      },
-      "avatar": {
-        "href": "https:\/\/bitbucket.org\/account\/user\/atlassian\/projects\/PROJ\/avatar\/32"
-      }
-    },
-    "name": "Project: Atlassian"
-  },
-  "language": "",
   "created_on": "2013-04-15T03:05:05.595458+00:00",
-  "mainbranch": {
-    "type": "branch",
-    "name": "master"
-  },
-  "full_name": "atlassian\/stash-example-plugin",
-  "has_issues": false,
+  "full_name": "atlassian/stash-example-plugin",
   "owner": {
     "username": "atlassian",
     "display_name": "Atlassian",
@@ -85,20 +58,69 @@
     "uuid": "{02b941e3-cfaa-40f9-9a58-cec53e20bdc3}",
     "links": {
       "self": {
-        "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian"
+        "href": "https://api.bitbucket.org/2.0/workspaces/%7B02b941e3-cfaa-40f9-9a58-cec53e20bdc3%7D"
       },
       "html": {
-        "href": "https:\/\/bitbucket.org\/atlassian\/"
+        "href": "https://bitbucket.org/%7B02b941e3-cfaa-40f9-9a58-cec53e20bdc3%7D/"
       },
       "avatar": {
-        "href": "https:\/\/bitbucket.org\/account\/atlassian\/avatar\/32\/"
+        "href": "https://bitbucket.org/account/atlassian/avatar/"
       }
     }
   },
-  "updated_on": "2018-04-01T16:36:35.970175+00:00",
   "size": 1116345,
+  "uuid": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
   "type": "repository",
+  "website": "",
+  "override_settings": {
+    "branching_model": false,
+    "default_merge_strategy": false,
+    "branch_restrictions": false
+  },
+  "description": "Examples on how to decorate various pages around Stash.",
+  "has_issues": false,
   "slug": "stash-example-plugin",
-  "is_private": true,
-  "description": "Examples on how to decorate various pages around Stash."
+  "is_private": false,
+  "name": "stash-example-plugin",
+  "language": "",
+  "fork_policy": "allow_forks",
+  "project": {
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/projects/PROJ"
+      },
+      "html": {
+        "href": "https://bitbucket.org/atlassian/workspace/projects/PROJ"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/user/atlassian/projects/PROJ/avatar/32?ts=1447290751"
+      }
+    },
+    "type": "project",
+    "name": "Project: Atlassian",
+    "key": "PROJ",
+    "uuid": "{8b56daff-dbc7-4cae-a7a3-1228c526906b}"
+  },
+  "mainbranch": {
+    "type": "branch",
+    "name": "master"
+  },
+  "workspace": {
+    "slug": "atlassian",
+    "type": "workspace",
+    "name": "Atlassian",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/workspaces/atlassian"
+      },
+      "html": {
+        "href": "https://bitbucket.org/atlassian/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/workspaces/atlassian/avatar/?ts=1612327398"
+      }
+    },
+    "uuid": "{02b941e3-cfaa-40f9-9a58-cec53e20bdc3}"
+  },
+  "updated_on": "2018-04-01T16:36:35.970175+00:00"
 }

--- a/scm/driver/bitbucket/testdata/repo.json.golden
+++ b/scm/driver/bitbucket/testdata/repo.json.golden
@@ -2,9 +2,13 @@
     "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
     "Namespace": "atlassian",
     "Name": "stash-example-plugin",
-    "Perm": null,
+    "Perm": {
+        "Pull": true,
+        "Push": true,
+        "Admin": true
+    },
     "Branch": "master",
-    "Private": true,
+    "Private": false,
     "Clone": "https://bitbucket.org/atlassian/stash-example-plugin.git",
     "CloneSSH": "git@bitbucket.org:atlassian/stash-example-plugin.git",
     "Link": "https://bitbucket.org/atlassian/stash-example-plugin",

--- a/scm/driver/bitbucket/testdata/team.json
+++ b/scm/driver/bitbucket/testdata/team.json
@@ -1,17 +1,37 @@
 {
-  "username": "atlassian",
-  "type": "team",
-  "display_name": "Atlassian",
   "uuid": "{02b941e3-cfaa-40f9-9a58-cec53e20bdc3}",
   "links": {
+    "owners": {
+      "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/members?q=permission%3D%22owner%22"
+    },
+    "hooks": {
+      "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/hooks"
+    },
     "self": {
-      "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian"
+      "href": "https://api.bitbucket.org/2.0/workspaces/atlassian"
+    },
+    "repositories": {
+      "href": "https://api.bitbucket.org/2.0/repositories/atlassian"
     },
     "html": {
-      "href": "https:\/\/bitbucket.org\/atlassian\/"
+      "href": "https://bitbucket.org/atlassian/"
     },
     "avatar": {
-      "href": "https:\/\/bitbucket.org\/account\/atlassian\/avatar\/32\/"
+      "href": "https://bitbucket.org/workspaces/atlassian/avatar/?ts=1612327398"
+    },
+    "members": {
+      "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/members"
+    },
+    "projects": {
+      "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/projects"
+    },
+    "snippets": {
+      "href": "https://api.bitbucket.org/2.0/snippets/atlassian"
     }
-  }
+  },
+  "created_on": "2018-11-29T02:26:39.297476+00:00",
+  "type": "workspace",
+  "slug": "atlassian",
+  "is_private": true,
+  "name": "Atlassian"
 }

--- a/scm/driver/bitbucket/testdata/teams.json
+++ b/scm/driver/bitbucket/testdata/teams.json
@@ -2,45 +2,41 @@
   "pagelen": 30,
   "values": [
     {
-      "username": "atlassian",
-      "website": null,
-      "display_name": "Atlassian",
-      "uuid": "{d5bb8c49-f033-4498-910e-7e4b546b04ee}",
+      "uuid": "{02b941e3-cfaa-40f9-9a58-cec53e20bdc3}",
       "links": {
+        "owners": {
+          "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/members?q=permission%3D%22owner%22"
+        },
         "hooks": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian\/hooks"
+          "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/hooks"
         },
         "self": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian"
+          "href": "https://api.bitbucket.org/2.0/workspaces/atlassian"
         },
         "repositories": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian"
+          "href": "https://api.bitbucket.org/2.0/repositories/atlassian"
         },
         "html": {
-          "href": "https:\/\/bitbucket.org\/atlassian\/"
-        },
-        "followers": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian\/followers"
+          "href": "https://bitbucket.org/atlassian/"
         },
         "avatar": {
-          "href": "https:\/\/bitbucket.org\/account\/atlassian\/avatar\/32\/"
+          "href": "https://bitbucket.org/workspaces/atlassian/avatar/?ts=1612327398"
         },
         "members": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian\/members"
-        },
-        "following": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian\/following"
+          "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/members"
         },
         "projects": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/teams\/atlassian\/projects\/"
+          "href": "https://api.bitbucket.org/2.0/workspaces/atlassian/projects"
         },
         "snippets": {
-          "href": "https:\/\/api.bitbucket.org\/2.0\/snippets\/atlassian"
+          "href": "https://api.bitbucket.org/2.0/snippets/atlassian"
         }
       },
-      "created_on": "2012-11-08T19:05:39.080491+00:00",
-      "location": null,
-      "type": "team"
+      "created_on": "2018-11-29T02:26:39.297476+00:00",
+      "type": "workspace",
+      "slug": "atlassian",
+      "is_private": true,
+      "name": "Atlassian"
     }
   ],
   "page": 1,

--- a/scm/driver/bitbucket/user.go
+++ b/scm/driver/bitbucket/user.go
@@ -6,6 +6,7 @@ package bitbucket
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/drone/go-scm/scm"
@@ -29,7 +30,19 @@ func (s *userService) FindLogin(ctx context.Context, login string) (*scm.User, *
 }
 
 func (s *userService) FindEmail(ctx context.Context) (string, *scm.Response, error) {
-	return "", nil, scm.ErrNotSupported
+	out := new(emails)
+	res, err := s.client.do(ctx, "GET", "2.0/user/emails", nil, out)
+	if err != nil {
+		return "", res, err
+	}
+
+	for _, emailObj := range out.Values {
+		if emailObj.IsPrimary {
+			return emailObj.Email, res, nil
+		}
+	}
+
+	return "", res, errors.New("no primary email found")
 }
 
 type user struct {
@@ -47,6 +60,14 @@ type user struct {
 	} `json:"links"`
 	Type string `json:"type"`
 	UUID string `json:"uuid"`
+}
+
+type emails struct {
+	Values []struct {
+		IsPrimary   bool   `json:"is_primary"`
+		IsConfirmed bool   `json:"is_confirmed"`
+		Email       string `json:"email"`
+	} `json:"values"`
 }
 
 func convertUser(from *user) *scm.User {

--- a/scm/driver/bitbucket/user_test.go
+++ b/scm/driver/bitbucket/user_test.go
@@ -67,9 +67,18 @@ func TestUserLoginFind(t *testing.T) {
 }
 
 func TestUserFindEmail(t *testing.T) {
+	gock.New("https://api.bitbucket.org").
+		Get("2.0/user/emails").
+		Reply(200).
+		Type("application/json").
+		File("testdata/email.json")
+
 	client, _ := New("https://api.bitbucket.org")
-	_, _, err := client.Users.FindEmail(context.Background())
-	if err != scm.ErrNotSupported {
-		t.Errorf("Expect Not Supported error")
+	got, _, err := client.Users.FindEmail(context.Background())
+	if err != nil {
+		t.Errorf("Unexpected error")
+	}
+	if got != "utkarsh.gupta.cer15@itbhu.ac.in" {
+		t.Errorf("Unexpected Results")
 	}
 }

--- a/scm/driver/gitea/repo.go
+++ b/scm/driver/gitea/repo.go
@@ -39,7 +39,7 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	return convertRepository(out).Perm, res, err
 }
 
-func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, orgSlug string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("api/v1/user/repos?%s", encodeListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/gitea/repo_test.go
+++ b/scm/driver/gitea/repo_test.go
@@ -79,7 +79,7 @@ func TestRepoList(t *testing.T) {
 		File("testdata/repos.json")
 
 	client, _ := New("https://try.gitea.io")
-	got, _, err := client.Repositories.List(context.Background(), scm.ListOptions{})
+	got, _, err := client.Repositories.List(context.Background(), "", scm.ListOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -82,7 +82,7 @@ func (s *RepositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 }
 
 // List returns the user repository list.
-func (s *RepositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *RepositoryService) List(ctx context.Context, orgSlug string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("user/repos?%s", encodeListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/github/repo_test.go
+++ b/scm/driver/github/repo_test.go
@@ -110,7 +110,7 @@ func TestRepositoryList(t *testing.T) {
 		File("testdata/repos.json")
 
 	client := NewDefault()
-	got, res, err := client.Repositories.List(context.Background(), scm.ListOptions{Page: 1, Size: 30})
+	got, res, err := client.Repositories.List(context.Background(), "", scm.ListOptions{Page: 1, Size: 30})
 	if err != nil {
 		t.Error(err)
 		return

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -86,7 +86,7 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	return convertRepository(out).Perm, res, err
 }
 
-func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, orgSlug string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects?%s", encodeMemberListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/gitlab/repo_test.go
+++ b/scm/driver/gitlab/repo_test.go
@@ -143,7 +143,7 @@ func TestRepositoryList(t *testing.T) {
 		File("testdata/repos.json")
 
 	client := NewDefault()
-	got, res, err := client.Repositories.List(context.Background(), scm.ListOptions{Page: 1, Size: 30})
+	got, res, err := client.Repositories.List(context.Background(), "", scm.ListOptions{Page: 1, Size: 30})
 	if err != nil {
 		t.Error(err)
 		return

--- a/scm/driver/gogs/repo.go
+++ b/scm/driver/gogs/repo.go
@@ -38,7 +38,7 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	return convertRepository(out).Perm, res, err
 }
 
-func (s *repositoryService) List(ctx context.Context, _ scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, orgSlug string, _ scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("api/v1/user/repos")
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/gogs/repo_test.go
+++ b/scm/driver/gogs/repo_test.go
@@ -79,7 +79,7 @@ func TestRepositoryList(t *testing.T) {
 		File("testdata/repos.json")
 
 	client, _ := New("https://try.gogs.io")
-	got, _, err := client.Repositories.List(context.Background(), scm.ListOptions{})
+	got, _, err := client.Repositories.List(context.Background(), "", scm.ListOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -157,7 +157,7 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 }
 
 // List returns the user repository list.
-func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, orgSlug string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("rest/api/1.0/repos?%s", encodeListRoleOptions(opts))
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/stash/repo_test.go
+++ b/scm/driver/stash/repo_test.go
@@ -267,7 +267,7 @@ func TestRepositoryList(t *testing.T) {
 		File("testdata/repos.json")
 
 	client, _ := New("http://example.com:7990")
-	got, res, err := client.Repositories.List(context.Background(), scm.ListOptions{Page: 3, Size: 25})
+	got, res, err := client.Repositories.List(context.Background(), "", scm.ListOptions{Page: 3, Size: 25})
 	if err != nil {
 		t.Error(err)
 	}

--- a/scm/example_test.go
+++ b/scm/example_test.go
@@ -81,7 +81,7 @@ func ExampleRepository_list() {
 		Size: 30,
 	}
 
-	repos, _, err := client.Repositories.List(ctx, opts)
+	repos, _, err := client.Repositories.List(ctx, "", opts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -117,7 +117,7 @@ type (
 		FindPerms(context.Context, string) (*Perm, *Response, error)
 
 		// List returns a list of repositories.
-		List(context.Context, ListOptions) ([]*Repository, *Response, error)
+		List(context.Context, string, ListOptions) ([]*Repository, *Response, error)
 
 		// ListHooks returns a list or repository hooks.
 		ListHooks(context.Context, string, ListOptions) ([]*Hook, *Response, error)


### PR DESCRIPTION
Updated outdated bitbucket methods

- [user find email](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-users/#api-user-emails-get)
- [bitbucket list org](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-workspaces-get)
- [bitbucket list repos and get repo](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-get)
[Repo permissions](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-user-permissions-repositories-get)
- updated unit test as per the changes


