### PR TITLE
changed expiryDelta to 15 minutes

### DIFF
--- a/scm/transport/oauth2/refresh.go
+++ b/scm/transport/oauth2/refresh.go
@@ -18,7 +18,7 @@ import (
 // expiryDelta determines how earlier a token should be considered
 // expired than its actual expiration time. It is used to avoid late
 // expirations due to client-server time mismatches.
-const expiryDelta = time.Minute
+const expiryDelta = 15 * time.Minute
 
 // Refresher is an http.RoundTripper that refreshes oauth
 // tokens, wrapping a base RoundTripper and refreshing the


### PR DESCRIPTION
expiryDelta determines how earlier a token should be considered expired than its actual expiration time. It is used to avoid late expirations due to client-server time mismatches.